### PR TITLE
Favor BYDAY/BYMONTHDAY over BYSETPOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ class ControlledRender extends Component {
 | **hideEnd** | `boolean` | If `true` ending form is not rendered. Default: `false` |
 | **hideError** | `boolean` | If `true` error alert is not rendered. Default: `false` |
 | **weekStartsOnSunday** | `boolean` | If set to `true`, weeks starts on Sunday (both for views and RRule string). Default: `false` |
+| **allowBYSETPOS** | `boolean` | If set to `false`, repeat options for `(nth) Weekday` and `(nth) Weekend day` are hidden. This prevents the use of the `BYSETPOS` field in the resulting RRULE output, which is not fully supported by other RRULE libraries. Default: `true` |
 
 ## License 
 MIT

--- a/src/lib/components/ReactRRuleGenerator.js
+++ b/src/lib/components/ReactRRuleGenerator.js
@@ -124,6 +124,7 @@ ReactRRuleGenerator.propTypes = {
     hideEnd: PropTypes.bool,
     hideError: PropTypes.bool,
     weekStartsOnSunday: PropTypes.bool,
+    allowBYSETPOS: PropTypes.bool,
   }),
   value: PropTypes.string,
   onChange: PropTypes.func,

--- a/src/lib/components/Repeat/Monthly/OnThe.js
+++ b/src/lib/components/Repeat/Monthly/OnThe.js
@@ -9,8 +9,13 @@ const RepeatMonthlyOnThe = ({
   onThe,
   hasMoreModes,
   handleChange,
+  allowBYSETPOS,
 }) => {
   const isActive = mode === 'on the';
+  const filteredDays = DAYS.filter((d) => {
+    if (d === 'Weekday' || d === 'Weekend day') return allowBYSETPOS;
+    return true;
+  });
 
   return (
     <div className={`form-group row d-flex align-items-sm-center ${!isActive && 'opacity-50'}`}>
@@ -59,7 +64,7 @@ const RepeatMonthlyOnThe = ({
           disabled={!isActive}
           onChange={handleChange}
         >
-          {DAYS.map(day => <option key={day} value={day}>{day}</option>)}
+          {filteredDays.map(day => <option key={day} value={day}>{day}</option>)}
         </select>
       </div>
 
@@ -75,6 +80,7 @@ RepeatMonthlyOnThe.propTypes = {
   }).isRequired,
   hasMoreModes: PropTypes.bool.isRequired,
   handleChange: PropTypes.func.isRequired,
+  allowBYSETPOS: PropTypes.bool.isRequired,
 };
 
 export default RepeatMonthlyOnThe;

--- a/src/lib/components/Repeat/Monthly/OnThe.js
+++ b/src/lib/components/Repeat/Monthly/OnThe.js
@@ -13,7 +13,7 @@ const RepeatMonthlyOnThe = ({
 }) => {
   const isActive = mode === 'on the';
   const filteredDays = DAYS.filter((d) => {
-    if (d === 'Weekday' || d === 'Weekend day') return allowBYSETPOS;
+    if (d.match(/^week/i)) return allowBYSETPOS;
     return true;
   });
 

--- a/src/lib/components/Repeat/Monthly/index.js
+++ b/src/lib/components/Repeat/Monthly/index.js
@@ -17,6 +17,7 @@ const RepeatMonthly = ({
 }) => {
   const isTheOnlyOneMode = option => options.modes === option;
   const isOptionAvailable = option => !options.modes || isTheOnlyOneMode(option);
+  const allowBYSETPOS = typeof options.allowBYSETPOS === 'undefined' ? true : options.allowBYSETPOS;
 
   return (
     <div>
@@ -54,6 +55,7 @@ const RepeatMonthly = ({
           onThe={onThe}
           hasMoreModes={!isTheOnlyOneMode('on the')}
           handleChange={handleChange}
+          allowBYSETPOS={allowBYSETPOS}
         />
       )}
 
@@ -70,6 +72,7 @@ RepeatMonthly.propTypes = {
     onThe: PropTypes.object.isRequired,
     options: PropTypes.shape({
       modes: PropTypes.oneOf(['on', 'on the']),
+      allowBYSETPOS: PropTypes.bool,
     }).isRequired,
   }).isRequired,
   handleChange: PropTypes.func.isRequired,

--- a/src/lib/components/Repeat/Yearly/OnThe.js
+++ b/src/lib/components/Repeat/Yearly/OnThe.js
@@ -9,8 +9,13 @@ const RepeatYearlyOnThe = ({
   onThe,
   hasMoreModes,
   handleChange,
+  allowBYSETPOS,
 }) => {
   const isActive = mode === 'on the';
+  const filteredDays = DAYS.filter((d) => {
+    if (d === 'Weekday' || d === 'Weekend day') return allowBYSETPOS;
+    return true;
+  });
 
   return (
     <div className={`form-group row d-flex align-items-sm-center ${!isActive && 'opacity-50'}`}>
@@ -59,7 +64,7 @@ const RepeatYearlyOnThe = ({
           disabled={!isActive}
           onChange={handleChange}
         >
-          {DAYS.map(day => <option key={day} value={day}>{day}</option>)}
+          {filteredDays.map(day => <option key={day} value={day}>{day}</option>)}
         </select>
       </div>
 
@@ -93,6 +98,7 @@ RepeatYearlyOnThe.propTypes = {
     day: PropTypes.oneOf(DAYS).isRequired,
   }).isRequired,
   hasMoreModes: PropTypes.bool.isRequired,
+  allowBYSETPOS: PropTypes.bool.isRequired,
   handleChange: PropTypes.func.isRequired,
 };
 

--- a/src/lib/components/Repeat/Yearly/OnThe.js
+++ b/src/lib/components/Repeat/Yearly/OnThe.js
@@ -13,7 +13,7 @@ const RepeatYearlyOnThe = ({
 }) => {
   const isActive = mode === 'on the';
   const filteredDays = DAYS.filter((d) => {
-    if (d === 'Weekday' || d === 'Weekend day') return allowBYSETPOS;
+    if (d.match(/^week/i)) return allowBYSETPOS;
     return true;
   });
 

--- a/src/lib/components/Repeat/Yearly/index.js
+++ b/src/lib/components/Repeat/Yearly/index.js
@@ -15,6 +15,8 @@ const RepeatYearly = ({
 }) => {
   const isTheOnlyOneMode = option => options.modes === option;
   const isOptionAvailable = option => !options.modes || isTheOnlyOneMode(option);
+  const allowBYSETPOS = typeof options.allowBYSETPOS === 'undefined' ? true : options.allowBYSETPOS;
+
   return (
     <div>
       {isOptionAvailable('on') && (
@@ -33,6 +35,7 @@ const RepeatYearly = ({
           onThe={onThe}
           hasMoreModes={!isTheOnlyOneMode('on the')}
           handleChange={handleChange}
+          allowBYSETPOS={allowBYSETPOS}
         />
       )}
     </div>
@@ -46,6 +49,7 @@ RepeatYearly.propTypes = {
     onThe: PropTypes.object.isRequired,
     options: PropTypes.shape({
       modes: PropTypes.oneOf(['on', 'on the']),
+      allowBYSETPOS: PropTypes.bool,
     }).isRequired,
   }).isRequired,
   handleChange: PropTypes.func.isRequired,

--- a/src/lib/utils/computeRRule/fromString/computeMonthlyOnTheWhich.js
+++ b/src/lib/utils/computeRRule/fromString/computeMonthlyOnTheWhich.js
@@ -1,6 +1,29 @@
 const computeMonthlyOnTheWhich = (data, rruleObj) => {
-  if (rruleObj.freq !== 1 || !rruleObj.bysetpos) {
+  if (rruleObj.freq !== 1 || !rruleObj.byweekday) {
     return data.repeat.monthly.onThe.which;
+  }
+
+  if (rruleObj.byweekday.length === 1) {
+    switch (rruleObj.byweekday[0].n) {
+      case 1: {
+        return 'First';
+      }
+      case 2: {
+        return 'Second';
+      }
+      case 3: {
+        return 'Third';
+      }
+      case 4: {
+        return 'Fourth';
+      }
+      case -1: {
+        return 'Last';
+      }
+      default: {
+        return data.repeat.monthly.onThe.which;
+      }
+    }
   }
 
   const bysetpos = (typeof rruleObj.bysetpos === 'number') ? rruleObj.bysetpos : rruleObj.bysetpos[0];

--- a/src/lib/utils/computeRRule/fromString/computeYearlyOnTheWhich.js
+++ b/src/lib/utils/computeRRule/fromString/computeYearlyOnTheWhich.js
@@ -3,6 +3,29 @@ const computeYearlyOnTheWhich = (data, rruleObj) => {
     return data.repeat.yearly.onThe.which;
   }
 
+  if (rruleObj.byweekday.length === 1) {
+    switch (rruleObj.byweekday[0].n) {
+      case 1: {
+        return 'First';
+      }
+      case 2: {
+        return 'Second';
+      }
+      case 3: {
+        return 'Third';
+      }
+      case 4: {
+        return 'Fourth';
+      }
+      case -1: {
+        return 'Last';
+      }
+      default: {
+        return data.repeat.monthly.onThe.which;
+      }
+    }
+  }
+
   const bysetpos = (typeof rruleObj.bysetpos === 'number') ? rruleObj.bysetpos : rruleObj.bysetpos[0];
 
   switch (bysetpos) {

--- a/src/lib/utils/computeRRule/toString/computeMonthlyOnThe.js
+++ b/src/lib/utils/computeRRule/toString/computeMonthlyOnThe.js
@@ -1,21 +1,24 @@
+import { RRule } from 'rrule';
+
 const computeMonthlyOnThe = (onThe) => {
   const repeat = {};
 
+  let bysetpos;
   switch (onThe.which) {
     case 'First':
-      repeat.bysetpos = 1;
+      bysetpos = 1;
       break;
     case 'Second':
-      repeat.bysetpos = 2;
+      bysetpos = 2;
       break;
     case 'Third':
-      repeat.bysetpos = 3;
+      bysetpos = 3;
       break;
     case 'Fourth':
-      repeat.bysetpos = 4;
+      bysetpos = 4;
       break;
     case 'Last':
-      repeat.bysetpos = -1;
+      bysetpos = -1;
       break;
     default:
       break;
@@ -23,34 +26,36 @@ const computeMonthlyOnThe = (onThe) => {
 
   switch (onThe.day) {
     case 'Monday':
-      repeat.byweekday = [0];
+      repeat.byweekday = [RRule.MO.nth(bysetpos)];
       break;
     case 'Tuesday':
-      repeat.byweekday = [1];
+      repeat.byweekday = [RRule.TU.nth(bysetpos)];
       break;
     case 'Wednesday':
-      repeat.byweekday = [2];
+      repeat.byweekday = [RRule.WE.nth(bysetpos)];
       break;
     case 'Thursday':
-      repeat.byweekday = [3];
+      repeat.byweekday = [RRule.TH.nth(bysetpos)];
       break;
     case 'Friday':
-      repeat.byweekday = [4];
+      repeat.byweekday = [RRule.FR.nth(bysetpos)];
       break;
     case 'Saturday':
-      repeat.byweekday = [5];
+      repeat.byweekday = [RRule.SA.nth(bysetpos)];
       break;
     case 'Sunday':
-      repeat.byweekday = [6];
+      repeat.byweekday = [RRule.SU.nth(bysetpos)];
       break;
     case 'Day':
-      repeat.byweekday = [0, 1, 2, 3, 4, 5, 6];
+      repeat.bymonthday = bysetpos;
       break;
     case 'Weekday':
       repeat.byweekday = [0, 1, 2, 3, 4];
+      repeat.bysetpos = bysetpos;
       break;
     case 'Weekend day':
       repeat.byweekday = [5, 6];
+      repeat.bysetpos = bysetpos;
       break;
     default:
       break;

--- a/src/lib/utils/computeRRule/toString/computeYearlyOnThe.js
+++ b/src/lib/utils/computeRRule/toString/computeYearlyOnThe.js
@@ -1,23 +1,25 @@
+import { RRule } from 'rrule';
 import { MONTHS } from '../../../constants/index';
 
 const computeYearlyOnThe = (onThe) => {
   const repeat = {};
 
+  let bysetpos;
   switch (onThe.which) {
     case 'First':
-      repeat.bysetpos = 1;
+      bysetpos = 1;
       break;
     case 'Second':
-      repeat.bysetpos = 2;
+      bysetpos = 2;
       break;
     case 'Third':
-      repeat.bysetpos = 3;
+      bysetpos = 3;
       break;
     case 'Fourth':
-      repeat.bysetpos = 4;
+      bysetpos = 4;
       break;
     case 'Last':
-      repeat.bysetpos = -1;
+      bysetpos = -1;
       break;
     default:
       break;
@@ -25,34 +27,36 @@ const computeYearlyOnThe = (onThe) => {
 
   switch (onThe.day) {
     case 'Monday':
-      repeat.byweekday = [0];
+      repeat.byweekday = [RRule.MO.nth(bysetpos)];
       break;
     case 'Tuesday':
-      repeat.byweekday = [1];
+      repeat.byweekday = [RRule.TU.nth(bysetpos)];
       break;
     case 'Wednesday':
-      repeat.byweekday = [2];
+      repeat.byweekday = [RRule.WE.nth(bysetpos)];
       break;
     case 'Thursday':
-      repeat.byweekday = [3];
+      repeat.byweekday = [RRule.TH.nth(bysetpos)];
       break;
     case 'Friday':
-      repeat.byweekday = [4];
+      repeat.byweekday = [RRule.FR.nth(bysetpos)];
       break;
     case 'Saturday':
-      repeat.byweekday = [5];
+      repeat.byweekday = [RRule.SA.nth(bysetpos)];
       break;
     case 'Sunday':
-      repeat.byweekday = [6];
+      repeat.byweekday = [RRule.SU.nth(bysetpos)];
       break;
     case 'Day':
-      repeat.byweekday = [0, 1, 2, 3, 4, 5, 6];
+      repeat.bymonthday = bysetpos;
       break;
     case 'Weekday':
       repeat.byweekday = [0, 1, 2, 3, 4];
+      repeat.bysetpos = bysetpos;
       break;
     case 'Weekend day':
       repeat.byweekday = [5, 6];
+      repeat.bysetpos = bysetpos;
       break;
     default:
       break;

--- a/src/lib/utils/configureInitialState.js
+++ b/src/lib/utils/configureInitialState.js
@@ -37,6 +37,7 @@ const configureState = (config = {}, calendarComponent, id) => {
         },
         options: {
           modes: config.yearly,
+          allowBYSETPOS: config.allowBYSETPOS,
         },
       },
       monthly: {
@@ -51,6 +52,7 @@ const configureState = (config = {}, calendarComponent, id) => {
         },
         options: {
           modes: config.monthly,
+          allowBYSETPOS: config.allowBYSETPOS,
         },
       },
       weekly: {


### PR DESCRIPTION
Given:
- Most of the functionality from BYSETPOS can be handled with BYMONTHDAY
- Few other libraries handling RRULE support BYSETPOS
    - Not supported in text display/parsing in `rrule.js`
    - Not supported by `ice_cube` in Ruby

This changes the repeat options to favor display/generation of rules
without BYSETPOS. This is configurable via an `allowBYSETPOS` config
field.